### PR TITLE
Read file sync example takes 225 MB of memory and 7.1 seconds

### DIFF
--- a/readfilesync.js
+++ b/readfilesync.js
@@ -1,0 +1,8 @@
+const fs = require('fs');
+
+const allFileContents = fs.readFileSync('broadband.sql', 'utf-8');
+allFileContents.split(/\r?\n/).forEach(line =>  {
+  console.log(`Line from file: ${line}`);
+});
+const used = process.memoryUsage().heapUsed / 1024 / 1024;
+console.log(`The script uses approximately ${Math.round(used * 100) / 100} MB`);


### PR DESCRIPTION
![Screen Shot 2021-10-07 at 9 09 09 pm](https://user-images.githubusercontent.com/170554/136364628-4f21a2eb-e6af-45c4-88bc-26120663b3c4.png)
